### PR TITLE
Update syntax.grammar.d.ts

### DIFF
--- a/src/syntax.grammar.d.ts
+++ b/src/syntax.grammar.d.ts
@@ -1,3 +1,3 @@
-import {Parser} from "lezer"
+import {LRParser} from "@lezer/lr"
 
-export declare const parser: Parser
+export declare const parser: LRParser


### PR DESCRIPTION
When I use lang-example. syntax.grammar.d.ts file will throw the warning message, "Cannot find module 'lezer' or its corresponding type declarations.ts.". So I update 'lezer' module to "@lezer/LRParser" to fix this issue.