### PR TITLE
Clarify @codemirror namespace is closed to third parties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Things you'll need to do (see the [language support example](https://codemirror.
 
  * Optionally add a license.
 
- * Publish. If you want to use a `@codemirror/lang-...` package name, open an [issue](https://github.com/codemirror/codemirror.next/issues) to ask for npm publish rights for that name.
+ * Publish. The `@codemirror` namespace is not open to third parties, so publish under `codemirror-lang-EXAMPLE` or similar.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@codemirror/lang-EXAMPLE",
+  "name": "codemirror-lang-EXAMPLE",
   "version": "0.1.0",
   "description": "EXAMPLE language support for CodeMirror",
   "scripts": {


### PR DESCRIPTION
https://github.com/codemirror/dev/issues/912#issuecomment-1191592668

> No, I'm not opening up the https://github.com/codemirror package space to 3rd parties. Go with codemirror-lang-rome-ast or something similar instead.