### PR TITLE
Major bump rollup-plugin-ts from 2.0.4 to 3.0.2, fixes #9

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@lezer/highlight": "^1.0.0",
     "@codemirror/language": "^6.0.0",
+    "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "mocha": "^9.0.1",
     "rollup": "^2.60.2",
     "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-ts": "^2.0.4",
+    "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.3.4"
   },
   "license": "MIT"


### PR DESCRIPTION
The current language example is one major out of date on its rollup typescript plugin (`2.0.4` vs `3.0.2`.)  On Windows, the older plugin fails.

Updating the plugin resolves this, as discovered by @corwin-of-amber.  That is the purpose of this PR, which has only been tested on Windows.

`npm` also chose to rearrange your dependencies to alphabetize them

This pr resolves issue #9

----

```
john@DESKTOP-26H4050 MINGW64 /e/projects/lang-example (main)
$ npm install

> codemirror-lang-EXAMPLE@0.1.0 prepare
> rollup -c


src/index.ts → dist/index.cjs, ./dist...
[!] (plugin Typescript) TypeError: path.charCodeAt is not a function
src/index.ts
TypeError: path.charCodeAt is not a function
    at getEncodedRootLength (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:7826:24)
    at Object.isRootedDiskPath (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:7733:16)
    at Object.isExternalModuleNameRelative (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:12558:52)
    at tryLoadModuleUsingOptionalResolutionSettings (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:43831:17)
    at tryResolve (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:44036:28)
    at E:\projects\lang-example\node_modules\typescript\lib\typescript.js:44032:69
    at Object.forEach (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:377:30)
    at nodeModuleNameResolverWorker (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:44032:25)
    at nodeModuleNameResolver (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:44005:16)
    at Object.resolveModuleName (E:\projects\lang-example\node_modules\typescript\lib\typescript.js:43732:30)

npm ERR! code 1
npm ERR! path E:\projects\lang-example
npm ERR! command failed
npm ERR! command C:\WINDOWS\system32\cmd.exe /d /s /c rollup -c

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\Users\john\AppData\Local\npm-cache\_logs\2022-09-17T19_06_17_465Z-debug.log

john@DESKTOP-26H4050 MINGW64 /e/projects/lang-example (main)
$ npm i rollup-plugin-ts@latest

added 1 package, changed 5 packages, and audited 135 packages in 1s

found 0 vulnerabilities

john@DESKTOP-26H4050 MINGW64 /e/projects/lang-example (main)
$ npm install

> codemirror-lang-EXAMPLE@0.1.0 prepare
> rollup -c


src/index.ts → dist/index.cjs, ./dist...
created dist/index.cjs, ./dist in 1.7s

up to date, audited 135 packages in 4s

found 0 vulnerabilities
```

![image](https://user-images.githubusercontent.com/77482/190872858-fb594713-c353-44cd-a636-63cf221f2b48.png)
