### PR TITLE
Add scripts build aka do the thing

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@lezer/highlight": "^1.0.0",
     "@codemirror/language": "^6.0.0",
+    "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "mocha": "^9.0.1",
     "rollup": "^2.60.2",
     "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-ts": "^2.0.4",
+    "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.3.4"
   },
   "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "EXAMPLE language support for CodeMirror",
   "scripts": {
     "test": "mocha test/test.js",
-    "prepare": "rollup -c"
+    "prepare": "rollup -c",
+    "build": "npm run prepare && npm run test"
   },
   "type": "module",
   "main": "dist/index.cjs",


### PR DESCRIPTION
Users do not want to understand a library before running it to see if it works.

Idiomatically, this is handled with the `build` standard script block entry.

Less think is good think.  Be `Varrick Industries`.  [Do the thing](https://www.youtube.com/watch?v=mofRHlO1E_A&t=14s).

Fixes codemirror/lang-example#13.