### PR TITLE
Remove package lock from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /node_modules
-package-lock.json
 /dist
 /src/*.js
 /src/*.d.ts

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@lezer/highlight": "^1.0.0",
     "@codemirror/language": "^6.0.0",
+    "@lezer/highlight": "^1.0.0",
     "@lezer/lr": "^1.0.0"
   },
   "devDependencies": {
@@ -25,7 +25,7 @@
     "mocha": "^9.0.1",
     "rollup": "^2.60.2",
     "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-ts": "^2.0.4",
+    "rollup-plugin-ts": "^3.0.2",
     "typescript": "^4.3.4"
   },
   "license": "MIT"


### PR DESCRIPTION
Your tooling is excellent

One small point: package-lock should be in the repo, for three reasons.

1. This is how supply chain attacks can be investigated and prevented
2. A ci/cd path needs package.lock to do its installs; otherwise if it creates one on the spot it's not testing code as committed, but code as would have been created at any given time, and is subject to library drift
3. Several code scanners eg snyk treat it as positive signal and rank upwards for it
 
This PR removes package-lock from .gitignore. A subsequent PR will add an actual package lockfile, so that if you decide you want to do that yourself you can merge this, but if you don't want to be bothered you can just merge both.

Fixes codemirror/lang-example#15 (identical text)