### PR TITLE
Update dependencies to latest versions (including lezer/generator from 1.0.0 to 1.7.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "dependencies": {
-    "@codemirror/language": "^6.0.0",
-    "@lezer/highlight": "^1.0.0",
-    "@lezer/lr": "^1.0.0"
+    "@codemirror/language": "^6.10.2",
+    "@lezer/highlight": "^1.2.0",
+    "@lezer/lr": "^1.4.2"
   },
   "devDependencies": {
-    "@lezer/generator": "^1.0.0",
-    "mocha": "^9.0.1",
-    "rollup": "^2.60.2",
-    "rollup-plugin-dts": "^4.0.1",
-    "rollup-plugin-ts": "^3.0.2",
-    "typescript": "^4.3.4"
+    "@lezer/generator": "^1.7.1",
+    "mocha": "^10.7.0",
+    "rollup": "^4.19.1",
+    "rollup-plugin-dts": "^6.1.1",
+    "rollup-plugin-ts": "^3.4.5",
+    "typescript": "^5.5.4"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
The instructions at https://codemirror.net/examples/lang-package/ on how to create your own language package for CodeMirror  refer to this repo (https://github.com/codemirror/lang-example.)

I cloned the repo and began working through the instructions at https://lezer.codemirror.net/docs/guide/#writing-a-grammar and quickly hit the error:

```
Unexpected token '@asciiLetter'
```

which led me to https://discuss.codemirror.net/t/generator-throws-error-on-docs-example/5008, in which @marijnh comments:

> Could it be you’re using an older version of lezer-generator? That syntax (@asciiLetter) was introduced in 1.1.0.

...and sure enough, **lang-example** still depends on @lezer/generator 1.0.0.

Looks like it hasn't been updated in a few years, so this PR bumps the various dependencies to their latest versions:

**dependencies:**

- @codemirror/language: 6.0.0 => 6.10.2
- @lezer/highlight: 1.0.0 => 1.2.0
- @lezer/lr: @1.0.0 => 1.4.2 

**devDependencies:**

- @lezer/generator: 1.0.0 => 1.7.1
- @mocha: 9.0.1 => 10.7.0
- @rollup: 2.60.2 => 4.19.1
- @rollup-plugin-dts: 4.0.1 => 6.1.1
- @rollup-plugin-ts: 3.0.2 => 3.4.5
- @typescript: 4.3.4 => 5.5.4